### PR TITLE
Local tsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DocuWare REST API Sample
-This example is written by DocuWare. Feel free to fork and play around.  
-__We do not recommend__ to use this example for __productive__ purposes.  
+This example is written by DocuWare. Feel free to fork and play around.
+__We do not recommend__ to use this example for __productive__ purposes.
 It's more like to show a possible way to use our DocuWare
 REST API.
 
@@ -16,24 +16,26 @@ We've developed this project with [Visual Studio Code](https://code.visualstudio
 
 ## Project structure
 
-Startup: index.ts    
-Javascript output dir: ./dist    
+Startup: index.ts
+Javascript output dir: ./dist
 [The REST Wrapper class](./docs/classes/_restwrapper_.restcallwrapper.md)
 
 ### Custom typescript definition files
-- ["types/DW_Rest.d"](./docs/modules/_types_dw_rest_d_.md)  
+- ["types/DW_Rest.d"](./docs/modules/_types_dw_rest_d_.md)
   Wrappes the REST Schema here, so you can work with interfaces in code
-- ["types/DW_Request_Promise_Extension.d"](./docs/modules/_types_dw_request_promise_extension_d_.md)  
+- ["types/DW_Request_Promise_Extension.d"](./docs/modules/_types_dw_request_promise_extension_d_.md)
 Just a helper to work with node module 'request-promise'
-- ["types/timespan.d"](./docs/modules/_types_timespan_d_.md)   
+- ["types/timespan.d"](./docs/modules/_types_timespan_d_.md)
   Definition for module 'timespan' so you can work better in typescript
 
 ## How to start
-1. Restore node packages (run 'npm install')
+1. Install node packages (run 'npm install')
 2. Take a look in ["index.ts"](./docs/modules/_index_.md) and [restWrapper.ts](./docs/classes/_restwrapper_.restcallwrapper.md)
 3. Change credentials, organization and root URL
-4. Play around (Press F5 in VS Code or run it by 'npm start')
-5. In case of changing code, do not forget to run typescript compile(manually or by watcher)
+4. Play around, find the functions you need
+5. Compile the code so it can be run (`npm run tsc`)
+6. Run the code (`npm run start`)
+7. In case of changing code, do not forget to rerun typescript compile(manually or by watcher)
 
 ## Typedoc project reference documentation
 
@@ -41,4 +43,3 @@ Just a helper to work with node module 'request-promise'
 
 ## More information
 Feel free and take also a look on https://developer.docuware.com
-

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node ./dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "tsc": "tsc"
   },
   "keywords": [
     "docuware"


### PR DESCRIPTION
Again some white space trimming, sorry that's distracting.

The key element here is https://github.com/DocuWare/REST-Sample-TS/compare/master...nemchik:local-tsc?expand=1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R9

With this included users do not need to globally install typescript. Typescript is already included as a dev dependency, so it's not required to install globally in order to work. Running locally also ensures more consistent handling (ex: different versions of typescript being installed globally vs locally).

Running globally means you can run `tsc` as opposed to `npm run tsc` but this change does not restrict you from running globally, it just removes the requirement of running globally.