### PR TITLE
Add eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@typescript-eslint',
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,45 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
     "@microsoft/tsdoc": {
       "version": "0.12.20",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.20.tgz",
@@ -25,20 +64,23 @@
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
       "dev": true
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg==",
       "dev": true
     },
-    "@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.1.2",
@@ -50,31 +92,10 @@
         "@types/node": "*"
       }
     },
-    "@types/handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-      "dev": true,
-      "requires": {
-        "handlebars": "*"
-      }
-    },
-    "@types/highlight.js": {
-      "version": "9.12.4",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.4.tgz",
-      "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
-      "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.14.155",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.155.tgz",
-      "integrity": "sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==",
-      "dev": true
-    },
-    "@types/marked": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
       "dev": true
     },
     "@types/mime-types": {
@@ -90,9 +111,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.15.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.16.tgz",
-      "integrity": "sha512-QUb2Wgrw0aq7Pfk9LhjOXrnm8E7CmwHSa5fy0IYvxWSujNVV0wDkaGxnAsu2WZcdYRBerYqnf6e6Qiq1FkBxGw==",
+      "version": "11.15.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.20.tgz",
+      "integrity": "sha512-DY2QwdrBqNlsxdMehwzUtSsWHgYYPLVCAuXvOcu3wkzYmchbRunQ7OEZFOrmFoBLfA1ysz2Ypr6vtNP9WQkUaQ==",
       "dev": true
     },
     "@types/request": {
@@ -129,21 +150,82 @@
         "@types/request": "*"
       }
     },
-    "@types/shelljs": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.8.tgz",
-      "integrity": "sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/tough-cookie": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.7.tgz",
       "integrity": "sha512-rMQbgMGxnLsdn8e9aPVyuN+zMQLrZ2QW8xlv7eWS1mydfGXN+tsTKffcIzd8rGCcLdmi3xvQw2MDaZI1bBNTaw==",
       "dev": true
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.7.1.tgz",
+      "integrity": "sha512-3DB9JDYkMrc8Au00rGFiJLK2Ja9CoMP6Ut0sHsXp3ZtSugjNxvSSHTnKLfo4o+QmjYBJqEznDqsG1zj4F2xnsg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "3.7.1",
+        "debug": "^4.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.7.1.tgz",
+      "integrity": "sha512-TqE97pv7HrqWcGJbLbZt1v59tcqsSVpWTOf1AqrWK7n8nok2sGgVtYRuGXeNeLw3wXlLEbY1MKP3saB2HsO/Ng==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/types": "3.7.1",
+        "@typescript-eslint/typescript-estree": "3.7.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.7.1.tgz",
+      "integrity": "sha512-W4QV/gXvfIsccN8225784LNOorcm7ch68Fi3V4Wg7gmkWSQRKevO4RrRqWo6N/Z/myK1QAiGgeaXN57m+R/8iQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "3.7.1",
+        "@typescript-eslint/types": "3.7.1",
+        "@typescript-eslint/typescript-estree": "3.7.1",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.7.1.tgz",
+      "integrity": "sha512-PZe8twm5Z4b61jt7GAQDor6KiMhgPgf4XmUb9zdrwTbgtC/Sj29gXP1dws9yEn4+aJeyXrjsD9XN7AWFhmnUfg==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.7.1.tgz",
+      "integrity": "sha512-m97vNZkI08dunYOr2lVZOHoyfpqRs0KDpd6qkGaIcLGhQ2WPtgHOd/eVbsJZ0VYCQvupKrObAGTOvk3tfpybYA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "3.7.1",
+        "@typescript-eslint/visitor-keys": "3.7.1",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.7.1.tgz",
+      "integrity": "sha512-xn22sQbEya+Utj2IqJHGLA3i1jDzR43RzWupxojbSWnj3nnPLavaQmWe5utw03CwYao3r00qzXfgJMGNkrzrAA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
     },
     "abab": {
       "version": "2.0.3",
@@ -152,9 +234,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-globals": {
@@ -175,6 +257,12 @@
         }
       }
     },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
     "acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
@@ -190,6 +278,27 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
       }
     },
     "archiver": {
@@ -239,6 +348,15 @@
         }
       }
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
@@ -257,6 +375,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -344,10 +468,83 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -356,13 +553,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
     },
     "compress-commons": {
       "version": "2.1.1",
@@ -426,6 +616,17 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
     "cssom": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
@@ -473,6 +674,15 @@
         }
       }
     },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -483,6 +693,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "domexception": {
       "version": "1.0.1",
@@ -502,6 +721,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -509,6 +734,21 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.2",
@@ -521,6 +761,127 @@
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
+    },
+    "eslint": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.5.0.tgz",
+      "integrity": "sha512-vlUP10xse9sWt9SGRtcr1LAC67BENcQMFeV+w5EvLEoFe3xJ8cF1Skd0msziRx/VMC+72B4DxreCE+OR12OA6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.0",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "espree": "^7.2.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.2.0.tgz",
+      "integrity": "sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.3.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.3.0"
       }
     },
     "esprima": {
@@ -528,6 +889,32 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
     },
     "estraverse": {
       "version": "4.3.0",
@@ -567,6 +954,32 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -588,12 +1001,12 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
@@ -602,6 +1015,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -622,6 +1041,24 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
       }
     },
     "graceful-fs": {
@@ -656,10 +1093,16 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "highlight.js": {
-      "version": "9.18.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-      "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
+      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -700,6 +1143,28 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -725,6 +1190,27 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -735,10 +1221,32 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -779,6 +1287,12 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
         "tough-cookie": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -800,6 +1314,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -857,19 +1377,19 @@
       "dev": true
     },
     "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -902,10 +1422,16 @@
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
+    "lunr": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+      "dev": true
+    },
     "marked": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
       "dev": true
     },
     "mime-db": {
@@ -935,10 +1461,31 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "normalize-path": {
@@ -966,17 +1513,17 @@
       }
     },
     "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "p-finally": {
@@ -989,6 +1536,15 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -999,6 +1555,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -1023,14 +1585,14 @@
       "dev": true
     },
     "polly-js": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/polly-js/-/polly-js-1.6.5.tgz",
-      "integrity": "sha512-gGouufZpvrYBAeGkLJfty/89hAvFYia3lCxufMj066+aT9ZnR1Edfn/cAkY71Y22EcMPGfIKV4Z4iyi/+YauwQ=="
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/polly-js/-/polly-js-1.6.7.tgz",
+      "integrity": "sha512-z4EiuiCprrHbO78J7Tg52riNxKeGrPrdL4yPhQkPHtu+xnyzLs4PDTUnH1MJ2vlsML/Xc0gGWCCKoC1Z/XJYkw=="
     },
     "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
     "process-nextick-args": {
@@ -1087,6 +1649,12 @@
         "resolve": "^1.1.6"
       }
     },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
@@ -1126,19 +1694,19 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
-      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.19"
       }
     },
     "request-promise-native": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
-      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
       "requires": {
-        "request-promise-core": "1.1.3",
+        "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
       },
@@ -1163,6 +1731,21 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1179,6 +1762,27 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
     "shelljs": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
@@ -1190,10 +1794,27 @@
         "rechoir": "^0.6.2"
       }
     },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
@@ -1217,6 +1838,34 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1225,11 +1874,47 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      }
     },
     "tar-stream": {
       "version": "2.1.2",
@@ -1242,6 +1927,12 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.1.1"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "timespan": {
       "version": "2.3.0",
@@ -1267,6 +1958,21 @@
         "punycode": "^2.1.0"
       }
     },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -1290,52 +1996,46 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "^1.2.1"
       }
     },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typedoc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
-      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+      "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "^5.0.3",
-        "@types/handlebars": "^4.0.38",
-        "@types/highlight.js": "^9.12.3",
-        "@types/lodash": "^4.14.110",
-        "@types/marked": "^0.4.0",
-        "@types/minimatch": "3.0.3",
-        "@types/shelljs": "^0.8.0",
-        "fs-extra": "^7.0.0",
-        "handlebars": "^4.0.6",
-        "highlight.js": "^9.13.1",
-        "lodash": "^4.17.10",
-        "marked": "^0.4.0",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.0.0",
+        "lodash": "^4.17.15",
+        "lunr": "^2.3.8",
+        "marked": "1.0.0",
         "minimatch": "^3.0.0",
-        "progress": "^2.0.0",
-        "shelljs": "^0.8.2",
-        "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.2.x"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-          "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
-          "dev": true
-        }
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.10.2"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-      "dev": true
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.8"
+      }
     },
     "typedoc-plugin-markdown": {
       "version": "1.2.1",
@@ -1347,20 +2047,17 @@
       }
     },
     "typescript": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
-      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
-      "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
+      "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3"
-      }
+      "optional": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -1385,6 +2082,12 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -1437,6 +2140,15 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "with-open-file": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz",
@@ -1463,6 +2175,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "ws": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "content-disposition": "^0.5.3",
     "https": "^1.0.0",
     "mime-types": "^2.1.23",
-    "polly-js": "^1.6.3",
+    "polly-js": "^1.6.7",
     "read-chunk": "^3.2.0",
     "request": "^2.88.0",
-    "request-promise-native": "^1.0.7",
+    "request-promise-native": "^1.0.9",
     "timespan": "^2.3.0",
     "tough-cookie": "^3.0.1"
   },
@@ -31,15 +31,15 @@
     "@types/archiver": "^2.1.3",
     "@types/content-disposition": "^0.5.2",
     "@types/mime-types": "^2.1.0",
-    "@types/node": "^11.13.4",
+    "@types/node": "^11.15.20",
     "@types/request": "^2.48.1",
     "@types/request-promise-native": "^1.0.15",
     "@types/tough-cookie": "^2.3.5",
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
-    "eslint": "^7.2.0",
-    "typedoc": "^0.14.2",
+    "@typescript-eslint/eslint-plugin": "^3.7.1",
+    "@typescript-eslint/parser": "^3.7.1",
+    "eslint": "^7.5.0",
+    "typedoc": "^0.17.8",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^3.4.3"
+    "typescript": "^3.9.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Sample application to call DocuWare REST API with http client 'request'",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "start": "node ./dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "tsc": "tsc"
@@ -34,6 +35,9 @@
     "@types/request": "^2.48.1",
     "@types/request-promise-native": "^1.0.15",
     "@types/tough-cookie": "^2.3.5",
+    "@typescript-eslint/eslint-plugin": "^3.2.0",
+    "@typescript-eslint/parser": "^3.2.0",
+    "eslint": "^7.2.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
     "typescript": "^3.4.3"

--- a/src/Annotations.ts
+++ b/src/Annotations.ts
@@ -10,7 +10,7 @@
  */
 export class TextEntry implements DWRest.ITextEntry {
     //type has to be first!!!!
-    public $type: string = 'DocuWare.DocumentContentProcessing.Annotations.TextEntry, DocuWare.DocumentContentProcessing.Annotations';
+    public $type = 'DocuWare.DocumentContentProcessing.Annotations.TextEntry, DocuWare.DocumentContentProcessing.Annotations';
     public Value: string;
     public Font: DWRest.IFont;
     public Location: DWRest.IAnnotationRectangle;
@@ -38,7 +38,7 @@ export class TextEntry implements DWRest.ITextEntry {
  */
 export class LineEntry implements DWRest.ILineEntry {
     //type has to be first!!!!
-    public $type: string = 'DocuWare.DocumentContentProcessing.Annotations.LineEntry, DocuWare.DocumentContentProcessing.Annotations';
+    public $type = 'DocuWare.DocumentContentProcessing.Annotations.LineEntry, DocuWare.DocumentContentProcessing.Annotations';
     public From: DWRest.IAnnotationPoint;
     public To: DWRest.IAnnotationPoint
     public Arrow?: boolean | undefined;
@@ -65,7 +65,7 @@ export class LineEntry implements DWRest.ILineEntry {
  */
 export class RectEntry implements DWRest.IRectEntry {
     //type has to be first!!!!
-    public $type: string = 'DocuWare.DocumentContentProcessing.Annotations.RectEntry, DocuWare.DocumentContentProcessing.Annotations';
+    public $type = 'DocuWare.DocumentContentProcessing.Annotations.RectEntry, DocuWare.DocumentContentProcessing.Annotations';
     public Location: DWRest.IAnnotationPoint;
     public Filled?: boolean | undefined;
     public Ellipse?: boolean | undefined;
@@ -91,7 +91,7 @@ export class RectEntry implements DWRest.IRectEntry {
  */
 export class PolyLineEntry implements DWRest.IPolyLineEntry {
     //type has to be first!!!!
-    public $type: string = 'DocuWare.DocumentContentProcessing.Annotations.PolyLineEntry, DocuWare.DocumentContentProcessing.Annotations';
+    public $type = 'DocuWare.DocumentContentProcessing.Annotations.PolyLineEntry, DocuWare.DocumentContentProcessing.Annotations';
     public Stroke: DWRest.IStroke[];
     public Created?: DWRest.ICreateInfo | undefined;
     public Color?: string | undefined;
@@ -103,6 +103,5 @@ export class PolyLineEntry implements DWRest.IPolyLineEntry {
     constructor(stroke: DWRest.IStroke[]) {
         this.Stroke = stroke;
     }
-   
-}
 
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,17 +10,16 @@ import polly from 'polly-js';
 import { RestCallWrapper } from './restWrapper'
 import { LineEntry } from './Annotations';
 import { DialogExpressionCondition, DialogExpression } from './DialogExpression';
-import path from 'path';
 
 const timeToWait: number = 60 * 1000; //MS
 
 //connection data
-const rootUrl: string = 'http://localhost/';
-const user: string = 'dwadmin';
-const password: string = 'admin';
-const organization: string = 'Peters Engineering';
-const hostID: string = '7b5ed19b-bfd6-46e9-8a3b-efd2a4499666'; //has to be unique per machine
-const fileCabinetID: string = '3f3c9aff-63e5-4433-99a5-ed6dbba1bb72';
+const rootUrl = 'http://localhost/';
+const user = 'dwadmin';
+const password = 'admin';
+const organization = 'Peters Engineering';
+const hostID = '7b5ed19b-bfd6-46e9-8a3b-efd2a4499666'; //has to be unique per machine
+const fileCabinetID = '3f3c9aff-63e5-4433-99a5-ed6dbba1bb72';
 
 //the REST Wrapper
 const restWrapper: RestCallWrapper = new RestCallWrapper(rootUrl);
@@ -43,28 +42,28 @@ polly()
     .executeForPromise(async () => {
 
         //#region Login, list organizations and filecabinets
-        let logonResponse: DWRest.ILogonResponse = await restWrapper.Logon(logonModel);
-        let organizations: DWRest.IOrganizations = await restWrapper.GetOrganizations(logonResponse);
-        let organization: DWRest.IOrganization = await restWrapper.GetOrganization();
-        let fileCabinets: DWRest.IFileCabinets = await restWrapper.GetFileCabinets(organization);
-        let fileCabinet: DWRest.IFileCabinet = await restWrapper.GetFileCabinet(fileCabinetID);
+        const logonResponse: DWRest.ILogonResponse = await restWrapper.Logon(logonModel);
+        const organizations: DWRest.IOrganizations = await restWrapper.GetOrganizations(logonResponse);
+        const organization: DWRest.IOrganization = await restWrapper.GetOrganization();
+        const fileCabinets: DWRest.IFileCabinets = await restWrapper.GetFileCabinets(organization);
+        const fileCabinet: DWRest.IFileCabinet = await restWrapper.GetFileCabinet(fileCabinetID);
         //#endregion
 
         //Get a special document
-        let specialDocument: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 30);
+        const specialDocument: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 30);
 
         //#region get dialogs and do searches
         await getPagedDocumentResults(fileCabinet);
 
         //Get all dialogs from a file cabinet
-        let dialogs: DWRest.IDialogsResponse = await restWrapper.GetAllDialogsFromFileCabinet(fileCabinet);
+        const dialogs: DWRest.IDialogsResponse = await restWrapper.GetAllDialogsFromFileCabinet(fileCabinet);
 
-        let firstDialog: DWRest.IDialog = await getFirstDialogOfType(fileCabinet, DWRest.DialogType.Search);
+        const firstDialog: DWRest.IDialog = await getFirstDialogOfType(fileCabinet, DWRest.DialogType.Search);
 
-        let documentsQueryResult: DWRest.IDocumentsQueryResult = await doSearch(fileCabinet, firstDialog);
+        const documentsQueryResult: DWRest.IDocumentsQueryResult = await doSearch(fileCabinet, firstDialog);
         //#endregion
 
-        let updatedFieldList: DWRest.IFieldList = await updateIndexEntry(specialDocument);
+        const updatedFieldList: DWRest.IFieldList = await updateIndexEntry(specialDocument);
 
         await downloadDocument(specialDocument);
 
@@ -85,7 +84,7 @@ polly()
         //#region Stamp or set annotation on document
         await stampAdocument(fileCabinet, specialDocument);
 
-        let documentForAnnotation: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 1, true);
+        const documentForAnnotation: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 1, true);
 
         await setAnAnnotation(documentForAnnotation);
         //#endregion
@@ -98,18 +97,18 @@ polly()
 
         //#region Merge and splitting of documents
         //Merge documents
-        let mergedDocument: DWRest.IDocument = await restWrapper.MergeDocument(fileCabinet, [223, 224, 225], DWRest.ContentMergeOperation.Clip);
+        const mergedDocument: DWRest.IDocument = await restWrapper.MergeDocument(fileCabinet, [223, 224, 225], DWRest.ContentMergeOperation.Clip);
 
         //Split documents
-        let splittedDocuments: DWRest.IDocumentsQueryResult = await restWrapper.DevideDocument(mergedDocument, DWRest.ContentDivideOperation.Unclip);
+        const splittedDocuments: DWRest.IDocumentsQueryResult = await restWrapper.DevideDocument(mergedDocument, DWRest.ContentDivideOperation.Unclip);
 
-        //#endregion 
+        //#endregion
 
         //#region Create user and assign or remove roles and groups
-        let newUser: DWRest.IUser = await createNewUser(organization);
+        const newUser: DWRest.IUser = await createNewUser(organization);
 
-        let group: DWRest.IGroup = await restWrapper.GetGroupByName(organization, 'MyTestGroup');
-        let role: DWRest.IRole = await restWrapper.GetRoleByName(organization, 'MyTestRole');
+        const group: DWRest.IGroup = await restWrapper.GetGroupByName(organization, 'MyTestGroup');
+        const role: DWRest.IRole = await restWrapper.GetRoleByName(organization, 'MyTestRole');
 
         //Assign user to group
         await restWrapper.AssignUserToGroup(newUser, group).then(async () => {
@@ -130,44 +129,44 @@ polly()
         //#endregion
 
         //#region Import and export documents
-        let pathToExportedDocument: string = await ExportADocument(fileCabinet);
+        const pathToExportedDocument: string = await ExportADocument(fileCabinet);
 
         await importAdocument(pathToExportedDocument);
 
         //#endregion
 
         //#region Do manual document locking
-        let documentforLock: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 229, true);
+        const documentforLock: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 229, true);
         await restWrapper.LockDocument(documentforLock, 60);
         await restWrapper.DeleteDocumentLock(documentforLock);
         //#endregion
 
         //#region Handle document application properties
-        let documentToAddApplicationProperties: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 229, true);
-        let appProperties: DWRest.IDocumentApplicationProperty[] = [{
+        const documentToAddApplicationProperties: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 229, true);
+        const appProperties: DWRest.IDocumentApplicationProperty[] = [{
             Name: 'CustomKey',
             Value: 'REST'
         }];
 
-        let addedApplicationProperties: DWRest.IDocumentApplicationProperties = await restWrapper.AddApplicationProperties(documentToAddApplicationProperties, appProperties);
+        const addedApplicationProperties: DWRest.IDocumentApplicationProperties = await restWrapper.AddApplicationProperties(documentToAddApplicationProperties, appProperties);
         //#endregion
 
         //#region Workflow handling
-        let workflows: DWRest.IWorkflows = await restWrapper.GetWorkflows(organization);
-        let theWorkflow: DWRest.IWorkflow | undefined = workflows.Workflow.find(w => w.Name === 'TestWorkflow');
+        const workflows: DWRest.IWorkflows = await restWrapper.GetWorkflows(organization);
+        const theWorkflow: DWRest.IWorkflow | undefined = workflows.Workflow.find(w => w.Name === 'TestWorkflow');
         if (theWorkflow) {
-            let task: DWRest.IWorkflowTasks = await restWrapper.GetWorkflowTasks(theWorkflow);
-            let fullLoadedTask: DWRest.IWorkflowTask = await restWrapper.LoadFullObjectFromPlatform<DWRest.IWorkflowTask>(task.Task[0].TaskOperations.BaseTaskOperations);
-            let result: any = await restWrapper.ConfirmWorkflowTask(fullLoadedTask);
+            const task: DWRest.IWorkflowTasks = await restWrapper.GetWorkflowTasks(theWorkflow);
+            const fullLoadedTask: DWRest.IWorkflowTask = await restWrapper.LoadFullObjectFromPlatform<DWRest.IWorkflowTask>(task.Task[0].TaskOperations.BaseTaskOperations);
+            const result: any = await restWrapper.ConfirmWorkflowTask(fullLoadedTask);
         }
         //#endregion
 
         //#region Add a tablefield to a document
 
-        let indexField: DWRest.IField = {
+        const indexField: DWRest.IField = {
             FieldName: 'InvoiceParts',
             ItemElementName: DWRest.ItemChoiceType.Table,
-            Item: { 
+            Item: {
                 Rows: [
                     {
                         Columns: [
@@ -203,8 +202,8 @@ polly()
     });
 
 async function importAdocument(pathToExportedDocument: string) {
-    let fcToImportTo: DWRest.IFileCabinet = await restWrapper.GetFileCabinet('98572c4a-86d5-4cab-bd77-5fda63ff7017');
-    let importResult: DWRest.IImportResult = await restWrapper.ImportDWXArchive(pathToExportedDocument, fcToImportTo, {
+    const fcToImportTo: DWRest.IFileCabinet = await restWrapper.GetFileCabinet('98572c4a-86d5-4cab-bd77-5fda63ff7017');
+    const importResult: DWRest.IImportResult = await restWrapper.ImportDWXArchive(pathToExportedDocument, fcToImportTo, {
         FieldMappings: [{
             Destination: 'COMPANY',
             Source: 'COMPANY'
@@ -213,13 +212,13 @@ async function importAdocument(pathToExportedDocument: string) {
 }
 
 async function ExportADocument(fileCabinet: DWRest.IFileCabinet) {
-    let documentForExport: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 229, true);
-    let pathToExportedDocument: string = await restWrapper.ExportDWXArchive(documentForExport, { ExportHistory: true, ExportTextShots: true });
+    const documentForExport: DWRest.IDocument = await restWrapper.GetDocumentByDocID(fileCabinet, 229, true);
+    const pathToExportedDocument: string = await restWrapper.ExportDWXArchive(documentForExport, { ExportHistory: true, ExportTextShots: true });
     return pathToExportedDocument;
 }
 
 async function createNewUser(organization: DWRest.IOrganization): Promise<DWRest.IUser> {
-    let newUser: DWRest.INewUser = {
+    const newUser: DWRest.INewUser = {
         Name: 'RESTTest',
         DBName: 'RESTTest',
         Email: 'resttest@localhost.de',
@@ -230,26 +229,26 @@ async function createNewUser(organization: DWRest.IOrganization): Promise<DWRest
 }
 
 async function transferDocumentsFromDocumentTrayToFileCabinet(fileCabinet: DWRest.IFileCabinet, docIdsToTransfer: number[]) {
-    let myDocumentTray: DWRest.IFileCabinet = await restWrapper.GetFileCabinet('b_bbc77c37-993c-4873-a7bf-47ecdfdab2d0');
-    let documentsQueryResult: DWRest.IDocumentsQueryResult = await restWrapper.TransferFromDocumentTrayToFileCabinet(docIdsToTransfer, myDocumentTray.Id, fileCabinet, true);
+    const myDocumentTray: DWRest.IFileCabinet = await restWrapper.GetFileCabinet('b_bbc77c37-993c-4873-a7bf-47ecdfdab2d0');
+    const documentsQueryResult: DWRest.IDocumentsQueryResult = await restWrapper.TransferFromDocumentTrayToFileCabinet(docIdsToTransfer, myDocumentTray.Id, fileCabinet, true);
 }
 
 async function transferDocumentsFromFileCabinetToFileCabinet(sourceFileCabinet: DWRest.IFileCabinet) {
-    let destinationFileCabinet: DWRest.IFileCabinet = await restWrapper.GetFileCabinet('1e623d39-974f-4677-a942-d9c60839a264');
-    let first5DocumentsToTransfer: DWRest.IDocumentsQueryResult = await restWrapper.GetDocumentQueryResultForSpecifiedCountFromFileCabinet(sourceFileCabinet, 5);
-    let transferredDocuments: DWRest.IDocumentsQueryResult = await restWrapper.TransferFromFileCabinetToFileCabinet(first5DocumentsToTransfer.Items, sourceFileCabinet.Id, destinationFileCabinet, true);
+    const destinationFileCabinet: DWRest.IFileCabinet = await restWrapper.GetFileCabinet('1e623d39-974f-4677-a942-d9c60839a264');
+    const first5DocumentsToTransfer: DWRest.IDocumentsQueryResult = await restWrapper.GetDocumentQueryResultForSpecifiedCountFromFileCabinet(sourceFileCabinet, 5);
+    const transferredDocuments: DWRest.IDocumentsQueryResult = await restWrapper.TransferFromFileCabinetToFileCabinet(first5DocumentsToTransfer.Items, sourceFileCabinet.Id, destinationFileCabinet, true);
 }
 
 async function setAnAnnotation(documentForAnnotation: DWRest.IDocument) {
     if (documentForAnnotation && documentForAnnotation.Sections) {
-        let firstSectionForAnnotation: DWRest.ISection = await restWrapper.LoadFullObjectFromPlatform<DWRest.ISection>(documentForAnnotation.Sections[0]);
-        let firstPage: DWRest.IPage = await restWrapper.GetPageByNumber(firstSectionForAnnotation, 0, true);
-        let firstPageData = firstPage.Data;
-        let lineInMiddleOfDocument = new LineEntry({ X: 0, Y: firstPageData.Height / 2 }, { X: firstPageData.Width, Y: firstPageData.Height / 2 });
+        const firstSectionForAnnotation: DWRest.ISection = await restWrapper.LoadFullObjectFromPlatform<DWRest.ISection>(documentForAnnotation.Sections[0]);
+        const firstPage: DWRest.IPage = await restWrapper.GetPageByNumber(firstSectionForAnnotation, 0, true);
+        const firstPageData = firstPage.Data;
+        const lineInMiddleOfDocument = new LineEntry({ X: 0, Y: firstPageData.Height / 2 }, { X: firstPageData.Width, Y: firstPageData.Height / 2 });
         lineInMiddleOfDocument.Color = '#f442b9';
         lineInMiddleOfDocument.StrokeWidth = 10;
         lineInMiddleOfDocument.Transparent = false;
-        let annotationToSet: DWRest.IAnnotation = {
+        const annotationToSet: DWRest.IAnnotation = {
             Layer: [{
                 Id: 1,
                 Items: [
@@ -257,15 +256,15 @@ async function setAnAnnotation(documentForAnnotation: DWRest.IDocument) {
                 ]
             }]
         };
-        let annotation: DWRest.IAnnotation = await restWrapper.PlaceAnnotation(firstPage, annotationToSet);
+        const annotation: DWRest.IAnnotation = await restWrapper.PlaceAnnotation(firstPage, annotationToSet);
     }
 }
 
 async function stampAdocument(fileCabinet: DWRest.IFileCabinet, document: DWRest.IDocument) {
     if (document && document.Sections) {
-        let fullLoadedFirstSectionForStamping: DWRest.ISection = await restWrapper.LoadFullObjectFromPlatform<DWRest.ISection>(document.Sections[0]);
-        let firstPage: DWRest.IPage = await restWrapper.GetPageByNumber(fullLoadedFirstSectionForStamping, 0);
-        let stampPlacement: DWRest.IStampPlacement = {
+        const fullLoadedFirstSectionForStamping: DWRest.ISection = await restWrapper.LoadFullObjectFromPlatform<DWRest.ISection>(document.Sections[0]);
+        const firstPage: DWRest.IPage = await restWrapper.GetPageByNumber(fullLoadedFirstSectionForStamping, 0);
+        const stampPlacement: DWRest.IStampPlacement = {
             Layer: 0,
             StampId: '7dc2ae96-b5cb-4aca-8b0e-3c7c8a163cb0',
             Field: [{
@@ -283,32 +282,32 @@ async function stampAdocument(fileCabinet: DWRest.IFileCabinet, document: DWRest
 }
 
 async function checkoutAndCheckinDocument(fileCabinet: DWRest.IFileCabinet, document: DWRest.IDocument) {
-    let fullLoadeddocumentForCheckout: DWRest.IDocument = await restWrapper.LoadFullObjectFromPlatform<DWRest.IDocument>(document);
-    let checkedOutDocumentPath: string = await restWrapper.CheckoutToFileSystem(fullLoadeddocumentForCheckout);
+    const fullLoadeddocumentForCheckout: DWRest.IDocument = await restWrapper.LoadFullObjectFromPlatform<DWRest.IDocument>(document);
+    const checkedOutDocumentPath: string = await restWrapper.CheckoutToFileSystem(fullLoadeddocumentForCheckout);
     if (fullLoadeddocumentForCheckout && fullLoadeddocumentForCheckout.Version) {
-        let currentVersion: DWRest.IDocumentVersion = fullLoadeddocumentForCheckout.Version;
+        const currentVersion: DWRest.IDocumentVersion = fullLoadeddocumentForCheckout.Version;
         //Higher minor version by one
         currentVersion.Minor = currentVersion.Minor + 1;
-        let theCheckInParamters: DWRest.ICheckInActionParameters = {
+        const theCheckInParamters: DWRest.ICheckInActionParameters = {
             DocumentAction: DWRest.DocumentAction.CheckIn,
             Comments: 'This is a comment.',
             CheckInReturnDocument: DWRest.CheckInReturnedDocument.CheckedIn,
             DocumentVersion: currentVersion //set new version
         };
-        let checkedInDocument: DWRest.IDocument = await restWrapper.CheckInFromFileSystem(fullLoadeddocumentForCheckout, checkedOutDocumentPath, theCheckInParamters);
+        const checkedInDocument: DWRest.IDocument = await restWrapper.CheckInFromFileSystem(fullLoadeddocumentForCheckout, checkedOutDocumentPath, theCheckInParamters);
     }
 }
 
 async function updateDocumentSection(document: DWRest.IDocument) {
     if (document && document.Sections) {
-        let firstSection: DWRest.ISection = document.Sections[0];
-        let fullLoadedFirstSection: DWRest.ISection = await restWrapper.LoadFullObjectFromPlatform<DWRest.ISection>(firstSection);
-        let updatedSection: DWRest.ISection = await restWrapper.EditDocumentSection(fullLoadedFirstSection, './upload/sample.txt');
+        const firstSection: DWRest.ISection = document.Sections[0];
+        const fullLoadedFirstSection: DWRest.ISection = await restWrapper.LoadFullObjectFromPlatform<DWRest.ISection>(firstSection);
+        const updatedSection: DWRest.ISection = await restWrapper.EditDocumentSection(fullLoadedFirstSection, './upload/sample.txt');
     }
 }
 
 async function storeDocument(fileCabinet: DWRest.IFileCabinet) {
-    let indexEntries: DWRest.IField[] = [
+    const indexEntries: DWRest.IField[] = [
         {
             FieldName: 'Company',
             Item: 'Doc Name Test Inc',
@@ -320,15 +319,15 @@ async function storeDocument(fileCabinet: DWRest.IFileCabinet) {
             ItemElementName: DWRest.ItemChoiceType.String
         }
     ];
-    let newCreatedDocument: DWRest.IDocument = await restWrapper.UploadDocument(fileCabinet, indexEntries, './upload/SAMPLE DOCUMENT.pdf');
+    const newCreatedDocument: DWRest.IDocument = await restWrapper.UploadDocument(fileCabinet, indexEntries, './upload/SAMPLE DOCUMENT.pdf');
 }
 
 async function storeBigDocumentWithoutIndex(fileCabinet: DWRest.IFileCabinet) {
-    let newCreatedDocument: DWRest.IDocument = await restWrapper.UploadBigDocument(fileCabinet, './upload/BIG SAMPLE DOCUMENT.pdf');
+    const newCreatedDocument: DWRest.IDocument = await restWrapper.UploadBigDocument(fileCabinet, './upload/BIG SAMPLE DOCUMENT.pdf');
 }
 
 async function storeBigDocumentXmlIndex(fileCabinet: DWRest.IFileCabinet) {
-    let indexEntries: string = 
+    const indexEntries =
     `<Document xmlns="http://dev.docuware.com/schema/public/services/platform">
         <Fields>
             <Field FieldName="COMPANY">
@@ -340,11 +339,11 @@ async function storeBigDocumentXmlIndex(fileCabinet: DWRest.IFileCabinet) {
         </Fields>
     </Document>`;
 
-    let newCreatedDocument: DWRest.IDocument = await restWrapper.UploadBigDocumentWithXmlIndex(fileCabinet, './upload/BIG SAMPLE DOCUMENT.pdf', indexEntries);
+    const newCreatedDocument: DWRest.IDocument = await restWrapper.UploadBigDocumentWithXmlIndex(fileCabinet, './upload/BIG SAMPLE DOCUMENT.pdf', indexEntries);
 }
 
 async function storeBigDocumentJsonIndex(fileCabinet: DWRest.IFileCabinet) {
-    let indexEntries: DWRest.IField[] = [
+    const indexEntries: DWRest.IField[] = [
         {
             FieldName: 'Company',
             Item: 'Doc Name Big JSON Test Inc',
@@ -357,39 +356,39 @@ async function storeBigDocumentJsonIndex(fileCabinet: DWRest.IFileCabinet) {
         }
     ];
 
-    let newCreatedDocument: DWRest.IDocument = await restWrapper.UploadBigDocumentWithJsonIndex(fileCabinet, './upload/BIG SAMPLE DOCUMENT.pdf', indexEntries);
+    const newCreatedDocument: DWRest.IDocument = await restWrapper.UploadBigDocumentWithJsonIndex(fileCabinet, './upload/BIG SAMPLE DOCUMENT.pdf', indexEntries);
 }
 
 async function downloadDocument(specialDocument: DWRest.IDocument) {
-    let fullLoadedDocument: DWRest.IDocument = await restWrapper.LoadFullObjectFromPlatform<DWRest.IDocument>(specialDocument);
-    let downloadPath: string = await restWrapper.DownloadDocument(fullLoadedDocument, false, DWRest.TargetFileType.Auto);
+    const fullLoadedDocument: DWRest.IDocument = await restWrapper.LoadFullObjectFromPlatform<DWRest.IDocument>(specialDocument);
+    const downloadPath: string = await restWrapper.DownloadDocument(fullLoadedDocument, false, DWRest.TargetFileType.Auto);
 }
 
 async function updateIndexEntry(specialDocument: DWRest.IDocument): Promise<DWRest.IFieldList> {
-    let customFieldOfDocument: DWRest.IField = getFieldByName(specialDocument, 'Status'); //Status is a custom field in filecabinet
+    const customFieldOfDocument: DWRest.IField = getFieldByName(specialDocument, 'Status'); //Status is a custom field in filecabinet
     //Update field value
     customFieldOfDocument.Item = 'Booked!';
     return await restWrapper.UpdateDocumentIndexValues(specialDocument, { Field: [customFieldOfDocument] });
 }
 
 async function doSearch(fileCabinet: DWRest.IFileCabinet, firstDialog: DWRest.IDialog): Promise<DWRest.IDocumentsQueryResult> {
-    let dialogExpression = new DialogExpression(DWRest.Operation.And, [
+    const dialogExpression = new DialogExpression(DWRest.Operation.And, [
         new DialogExpressionCondition('COMPANY', ['Home Improvement', 'Peters Engineering']),
         new DialogExpressionCondition('DOCUMENT_TYPE', ['Invoice out'])
     ]);
-    let query: string = await restWrapper.GetQueryUrlFromFileCabinet(fileCabinet, dialogExpression, firstDialog.Id, firstDialog.Query.Fields, 'COMPANY', DWRest.SortOrder.Desc);
+    const query: string = await restWrapper.GetQueryUrlFromFileCabinet(fileCabinet, dialogExpression, firstDialog.Id, firstDialog.Query.Fields, 'COMPANY', DWRest.SortOrder.Desc);
     return await restWrapper.GetQueryResults(query);
 }
 
 async function getFirstDialogOfType(fileCabinet: DWRest.IFileCabinet, dType: DWRest.DialogType): Promise<DWRest.IDialog> {
-    let dialogs: DWRest.IDialog[] = await restWrapper.GetDedicatedDialogsFromFileCabinet(fileCabinet, dType);
+    const dialogs: DWRest.IDialog[] = await restWrapper.GetDedicatedDialogsFromFileCabinet(fileCabinet, dType);
     return await restWrapper.LoadFullObjectFromPlatform<DWRest.IDialog>(dialogs[0]);
 }
 
 async function getPagedDocumentResults(fileCabinet: DWRest.IFileCabinet) {
-    let documents: DWRest.IDocument[] = await restWrapper.GetDocumentsFromFileCabinet(fileCabinet); //Try to avoid the get all at once
-    let first1DocumentsResult: DWRest.IDocumentsQueryResult = await restWrapper.GetDocumentQueryResultForSpecifiedCountFromFileCabinet(fileCabinet, 1);
-    let next1Documents: DWRest.IDocumentsQueryResult = await restWrapper.GetNextResultFromDocumentQueryResult(first1DocumentsResult);
+    const documents: DWRest.IDocument[] = await restWrapper.GetDocumentsFromFileCabinet(fileCabinet); //Try to avoid the get all at once
+    const first1DocumentsResult: DWRest.IDocumentsQueryResult = await restWrapper.GetDocumentQueryResultForSpecifiedCountFromFileCabinet(fileCabinet, 1);
+    const next1Documents: DWRest.IDocumentsQueryResult = await restWrapper.GetNextResultFromDocumentQueryResult(first1DocumentsResult);
 }
 
 async function updateDocumentTableField(document: DWRest.IDocument, tablefield: DWRest.IField) {
@@ -399,13 +398,13 @@ async function updateDocumentTableField(document: DWRest.IDocument, tablefield: 
 /**
  * Returns special field by name
  * Also proofs if system field is tried to manipulate
- * 
+ *
  * @param {DWRest.IDocument} document
  * @param {string} fieldName
  * @returns {DWRest.IField}
  */
 function getFieldByName(document: DWRest.IDocument, fieldName: string): DWRest.IField {
-    let field = document.Fields.find(f => f.FieldName.toLowerCase() === fieldName.toLowerCase());
+    const field = document.Fields.find(f => f.FieldName.toLowerCase() === fieldName.toLowerCase());
     if (!field) {
         throw new Error(`Field '${fieldName}' does not exist on document '${document.Id}'!`);
     }

--- a/src/restWrapper.ts
+++ b/src/restWrapper.ts
@@ -14,7 +14,6 @@ import fs from 'fs'; //https://nodejs.org/api/fs.html
 import mime, { contentType } from 'mime-types'; //https://www.npmjs.com/package/mime-types
 import querystring from 'querystring'; //https://nodejs.org/api/querystring.html
 import path from 'path';
-import archiver from 'archiver'; //https://www.npmjs.com/package/archiver
 import contentdisposition, { ContentDisposition } from 'content-disposition'; //https://github.com/jshttp/content-disposition
 import timespan from 'timespan'; //https://www.npmjs.com/package/timespan
 import readChunk from 'read-chunk';
@@ -83,9 +82,9 @@ class RestCallWrapper {
                 .then((logonResponse: DWRequestPromiseExtension.ILogonResponseWrapper) => {
                     try {
                         //Take care of errors and throttling
-                        let respondedCookies = logonResponse.headers["set-cookie"];
+                        const respondedCookies = logonResponse.headers["set-cookie"];
                         if (respondedCookies && respondedCookies.length > 0) {
-                            let cookieJar = request.jar();
+                            const cookieJar = request.jar();
                             respondedCookies.forEach((cookieString) => {
                                 //add cookies to jar
                                 cookieJar.setCookie(cookieString, this.platformRoot);
@@ -180,7 +179,7 @@ class RestCallWrapper {
      * @returns {(DWRest.IFileCabinet | undefined)}
      */
     GetDefaultDocumentTray(fileCabinets: DWRest.IFileCabinet[]): DWRest.IFileCabinet | undefined {
-        let result: DWRest.IFileCabinet | undefined = fileCabinets.find(f => f.Default === true && f.IsBasket === true);
+        const result: DWRest.IFileCabinet | undefined = fileCabinets.find(f => f.Default === true && f.IsBasket === true);
         return result;
     }
 
@@ -209,7 +208,7 @@ class RestCallWrapper {
      * @param {boolean}[fullLoad=false] fullLoad
      * @returns {Promise<DWRest.IDocument>}
      */
-    GetDocumentByDocID(fileCabinet: DWRest.IFileCabinet, docId: number, fullLoad: boolean = false): Promise<DWRest.IDocument> {
+    GetDocumentByDocID(fileCabinet: DWRest.IFileCabinet, docId: number, fullLoad = false): Promise<DWRest.IDocument> {
         const documentsLink: string = this.GetLink(fileCabinet, 'documents');
 
         return request.get(`${documentsLink}/${docId}`, this.docuWare_request_config)
@@ -269,7 +268,7 @@ class RestCallWrapper {
     }
 
     GetDialogLink(fileCabinet: DWRest.IFileCabinet, dialogType: DWRest.DialogType){
-        var dialogs: any = {
+        const dialogs: any = {
             [DWRest.DialogType.Search]: 'searches',
             [DWRest.DialogType.Store]: 'stores',
             [DWRest.DialogType.TaskList]: 'taskLists',
@@ -277,14 +276,14 @@ class RestCallWrapper {
             [DWRest.DialogType.InfoDialog]: null
         }
 
-        var dialog = dialogs[dialogType];
+        const dialog = dialogs[dialogType];
 
         //Null stands for not supported
         if (dialog === null){
             throw new Error('DialogType' + dialogType + ' not supported.');
         }
 
-        var returnValue = this.GetLink(fileCabinet, dialog)
+        const returnValue = this.GetLink(fileCabinet, dialog)
 
         if (!returnValue) {
             throw new Error('Missing dialog link');
@@ -507,7 +506,7 @@ class RestCallWrapper {
             const newDocument: DWRest.IDocument = {
                 Fields: indexFields
             };
-            var jsonValue = JSON.stringify(newDocument);
+            const jsonValue = JSON.stringify(newDocument);
 
             return this.UploadBigDocument(fileCabinet,pathToFile, jsonValue, IndexFileType.JSON);
         }
@@ -526,28 +525,27 @@ class RestCallWrapper {
     async UploadBigDocument(fileCabinet: DWRest.IFileCabinet, pathToFile: string, indexFields: any = null, indexFieldsType: IndexFileType = IndexFileType.NULL): Promise<DWRest.IDocument> {
         const documentsLink: string = this.GetLink(fileCabinet, 'documents');
 
-        const origChunkSize: number = 3000000;
-        var chunkSize: number;
+        const origChunkSize = 3000000;
+        let chunkSize: number;
         const fileName: string = path.basename(pathToFile);
         const contentType: string | false = mime.contentType(fileName);
 
-        var lastPostResult: any;
+        let lastPostResult: any;
 
-        let file: any = fs.readFileSync(pathToFile);
-        var fileSize   = file.length;
+        const file: any = fs.readFileSync(pathToFile);
+        const fileSize   = file.length;
 
         // Get file modified date time
-        var stats = fs.statSync(pathToFile);
-        var mtime = stats.mtime;
+        const stats = fs.statSync(pathToFile);
+        const mtime = stats.mtime;
 
-        var offset     = 0;
-        var firstCall: Boolean = true;
+        let firstCall = true;
 
-        var runCount = 0;
+        let runCount = 0;
 
-        var link = documentsLink;
+        let link = documentsLink;
 
-        for (var offset: number = 0; offset < fileSize; offset += origChunkSize) {
+        for (let offset = 0; offset < fileSize; offset += origChunkSize) {
             chunkSize = origChunkSize;
 
             // Set last chunk to correct size
@@ -555,10 +553,10 @@ class RestCallWrapper {
                 chunkSize = fileSize - offset;
             }
 
-            var chunk = readChunk.sync(pathToFile, offset, chunkSize);
+            const chunk = readChunk.sync(pathToFile, offset, chunkSize);
 
             runCount += 1;
-            var formData: any = null;
+            let formData: any = null;
 
             if (firstCall && indexFields !== null) {
                 formData = {
@@ -598,7 +596,7 @@ class RestCallWrapper {
             console.log(formData);
 
             // Add chunk headers
-            var xFileHeaders = {...this.docuWare_request_config.headers,
+            const xFileHeaders = {...this.docuWare_request_config.headers,
             'X-File-Name': fileName,
             'X-File-Size': fileSize.toString(),
             'X-File-ModifiedDate': mtime.toISOString(),
@@ -682,7 +680,7 @@ class RestCallWrapper {
 
         return new Promise<DWRest.IDocument>((resolve, reject) => {
 
-            const paramsPath: string = `${pathToFile}.json`;
+            const paramsPath = `${pathToFile}.json`;
 
             fs.writeFile(paramsPath, JSON.stringify(checkinParameters), async (err) => {
                 if (err) {
@@ -735,7 +733,7 @@ class RestCallWrapper {
      * @param {number} pageNumber
      * @returns {Promise<DWRest.IPage>}
      */
-    GetPageByNumber(fullLoadedSection: DWRest.ISection, pageNumber: number, fullLoad: boolean = false): Promise<DWRest.IPage> {
+    GetPageByNumber(fullLoadedSection: DWRest.ISection, pageNumber: number, fullLoad = false): Promise<DWRest.IPage> {
         return new Promise<DWRest.IPage>((resolve, reject) => {
 
             const pagesResultLink: string = this.GetLink(fullLoadedSection.Pages, 'nextBlock');
@@ -1021,7 +1019,7 @@ class RestCallWrapper {
                     throw new Error('No groups found!');
                 }
 
-                let theGroup: DWRest.IGroup | undefined = groupsResponse.Item.find(g => g.Name.toLowerCase() === name.toLowerCase());
+                const theGroup: DWRest.IGroup | undefined = groupsResponse.Item.find(g => g.Name.toLowerCase() === name.toLowerCase());
                 if (theGroup) {
                     return theGroup;
                 } else {
@@ -1047,7 +1045,7 @@ class RestCallWrapper {
                     throw new Error('No groups found!');
                 }
 
-                let theRole: DWRest.IRole | undefined = rolesResponse.Item.find(g => g.Name.toLowerCase() === name.toLowerCase());
+                const theRole: DWRest.IRole | undefined = rolesResponse.Item.find(g => g.Name.toLowerCase() === name.toLowerCase());
                 if (theRole) {
                     return theRole;
                 } else {
@@ -1069,7 +1067,7 @@ class RestCallWrapper {
         const importLink: string = this.GetLink(fileCabinet, 'importDocuments');
 
         const fileName: string = path.basename(pathOfDWX);
-        const contentType: string = 'application/vnd.docuware.platform.filescontainer+dwx';
+        const contentType = 'application/vnd.docuware.platform.filescontainer+dwx';
 
         const formData = {
             document: {
@@ -1213,13 +1211,13 @@ class RestCallWrapper {
      * @returns {Promise<void>}
      */
     ConfirmWorkflowTask(task: DWRest.IWorkflowTask): Promise<void> {
-        let firstDecision: DWRest.IDecision = task.Decisions[0];
+        const firstDecision: DWRest.IDecision = task.Decisions[0];
         if (firstDecision) {
             return this.LoadFullObjectFromPlatform<DWRest.IDecision>(firstDecision.DecisionOperations.BaseDecisionOperations)
                 .then((fullLoadedDecision: DWRest.IDecision) => {
                     const textFormField = fullLoadedDecision.TaskFormField.find(f => f.Item.FormFieldType === DWRest.FormTypeEnum.Text);
                     if (textFormField) {
-                        let confirmData: DWRest.IConfirmedData = {
+                        const confirmData: DWRest.IConfirmedData = {
                             ConfirmedFields: [
                                 {
                                     Id: textFormField.Item.Id,
@@ -1267,7 +1265,7 @@ class RestCallWrapper {
     private async DownloadFile(request: request.RequestPromise, reject: (reason?: any) => void, resolve: (value?: string) => void) {
         request.on('response', (response) => {
 
-            let cdString = response.headers['content-disposition'];
+            const cdString = response.headers['content-disposition'];
             if (cdString) {
                 const parsedContentDispositionString: ContentDisposition = contentdisposition.parse(cdString);
                 const fileName = parsedContentDispositionString.parameters['filename'];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,7 @@
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Including https://eslint.org/ and https://github.com/typescript-eslint/typescript-eslint allows editors (ex: VSCode) to display linting errors that can be addressed to improve the code in various ways. I have also included a commit fixing a number of things reported by eslint.

Note: I have not opted for https://palantir.github.io/tslint/ because it lists itself as deprecated and recommends using eslint with typescript-eslint.

Also, there are still more errors and warnings that the linter is reporting. I have only resolved the low hanging fruit that VSCode offered an automatic quick-fix for. The remaining issues do not seem to cause the existing code to have issues functioning, but fixing these issues would be beneficial to ensure the code quality.