### PR TITLE
Add the option to use Docuware Servers which are exposed on custom ports & improve vscode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program",
-            "program": "${workspaceFolder}\\dist\\index.js",
+            "program": "${workspaceFolder}/src/index.ts",
+            "preLaunchTask": "tsc: build - tsconfig.json",
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ]

--- a/src/restWrapper.ts
+++ b/src/restWrapper.ts
@@ -29,10 +29,11 @@ class RestCallWrapper {
      */
     platformRoot: string;
     docuWare_request_config: RequestPromiseOptions;
-    constructor(rootOfPlatform: string) {
-        this.platformRoot = rootOfPlatform;
+    constructor(rootOfPlatform: string, port?: number | undefined) {
+        this.platformRoot = port ? `${rootOfPlatform}:${port}` : rootOfPlatform;
         this.docuWare_request_config = {
             baseUrl: rootOfPlatform,
+            port,
             timeout: 1000,
             headers: {
                 'Accept': 'application/json', //to get always json as a response from DocuWare Platform
@@ -40,7 +41,7 @@ class RestCallWrapper {
             },
             withCredentials: true,
             maxRedirects: 5,
-            agent: (this.platformRoot.startsWith('https')) ? new https.Agent({ keepAlive: false }) : new http.Agent({ keepAlive: false }), //Seperated calls, can be changed to true. False is better for development. Do https/http switch
+            agent: (this.platformRoot.startsWith('https')) ? new https.Agent({ keepAlive: false, port }) : new http.Agent({ keepAlive: false }), //Seperated calls, can be changed to true. False is better for development. Do https/http switch
             json: true,
             resolveWithFullResponse: false //We want to get json objects returned directly, in some cases we set it to true during method call
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "sourceMap": true,
     "baseUrl": ".",
     "paths": {
       "*": [


### PR DESCRIPTION
This PR enhances the rest wrapper with a new port parameter which will allow the client to connect to docuware instances hosted on non standard ports.

There is also a slight change to the vscode config which will enable proper (just add a breakpoint in vscode anywhere and press `F5` to run) typescript debugging in vscode :)