### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Use GitHub's dependabot to keep packages up to date via automated pull requests.

It looked like some PRs from dependabot have already been made and merged:

https://github.com/DocuWare/REST-Sample-TS/pull/8
https://github.com/DocuWare/REST-Sample-TS/pull/7

I am not sure how those were created, possibly automated security updates. This file will create pull requests daily for any new versions of compatible package dependencies. SemVer is used in an attempt to not break compatibility.